### PR TITLE
Make nimble_parsec runtime: false

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule PathGlob.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:nimble_parsec, "~> 1.1.0"},
+      {:nimble_parsec, "~> 1.1.0", runtime: false},
       {:ex_doc, "~> 0.24", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
Makes it easier to not depend on it at runtime (but still use it at compile time to generate the parsers)

See https://github.com/elixir-lsp/elixir-ls/pull/609#issuecomment-954487450 for a discussion
