### PR TITLE
[Feature] allow pre-compiling pattern and matching on the resulting regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ glob without touching the filesystem. Internally, the glob pattern is compiled
 to a `Regex` and then checked via `String.match?/2`. If you want to compile the
 glob pattern ahead-of-time, you can use `PathGlob.compile/2`.
 
+## Usage
+
+```elixir
+# when using precompiled glob
+iex> PathGlob.compile("{foo,bar}") |> PathGlob.match?("foo")
+
+
+# with string input (slower on multiple matches with the same pattern)
+iex> PathGlob.match?("{foo,bar}", "foo")
+```
+
 ## Installation
 
 The package can be installed by adding `path_glob` to your list of dependencies

--- a/lib/path_glob.ex
+++ b/lib/path_glob.ex
@@ -38,21 +38,21 @@ defmodule PathGlob do
 
   ## Examples
 
-      iex> PathGlob.match?("lib/path_glob.ex", "{lib,test}/path_*.ex")
+      iex> PathGlob.match?("{lib,test}/path_*.ex", "lib/path_glob.ex")
       true
 
-      iex> PathGlob.match?("lib/.formatter.exs", "lib/*", match_dot: true)
+      iex> PathGlob.match?("lib/*", "lib/.formatter.exs", match_dot: true)
       true
   """
   def match?(path, glob, opts \\ [])
 
   @spec match?(String.t(), String.t(), match_dot: boolean()) :: boolean()
-  def match?(path, glob, opts) when is_binary(glob) do
+  def match?(glob, path,  opts) when is_binary(glob) do
     String.match?(path, compile(glob, opts))
   end
 
-  @spec match?(String.t(), Regex.t(), match_dot: boolean()) :: boolean()
-  def match?(path, glob, _opts) when is_struct(glob, Regex) do
+  @spec match?(Regex.t(), String.t(), match_dot: boolean()) :: boolean()
+  def match?(glob, path,  _opts) when is_struct(glob, Regex) do
     String.match?(path, glob)
   end
 

--- a/lib/path_glob.ex
+++ b/lib/path_glob.ex
@@ -44,9 +44,16 @@ defmodule PathGlob do
       iex> PathGlob.match?("lib/.formatter.exs", "lib/*", match_dot: true)
       true
   """
+  def match?(path, glob, opts \\ [])
+
   @spec match?(String.t(), String.t(), match_dot: boolean()) :: boolean()
-  def match?(path, glob, opts \\ []) do
+  def match?(path, glob, opts) when is_binary(glob) do
     String.match?(path, compile(glob, opts))
+  end
+
+  @spec match?(String.t(), Regex.t(), match_dot: boolean()) :: boolean()
+  def match?(path, glob, _opts) when is_struct(glob, Regex) do
+    String.match?(path, glob)
   end
 
   @doc """

--- a/test/path_glob_test.exs
+++ b/test/path_glob_test.exs
@@ -236,7 +236,7 @@ defmodule PathGlobTest do
     test "** pattern" do
       within_tmpdir("foo/bar/baz", fn ->
         assert "foo/bar/../bar" in Path.wildcard("foo/bar/../*")
-        assert PathGlob.match?("foo/bar/../bar", "foo/bar/../*")
+        assert PathGlob.match?("foo/bar/../*", "foo/bar/../bar")
       end)
     end
   end
@@ -257,9 +257,9 @@ defmodule PathGlobTest do
     # Testing this the normal way would cause us to traverse the entire
     # filesystem
     test "double star" do
-      assert PathGlob.match?(absolute("foo/bar"), "/**/bar")
-      assert PathGlob.match?(absolute("foo"), "/**/foo")
-      refute PathGlob.match?(absolute("foo/bar"), "/**/foo")
+      assert PathGlob.match?("/**/bar", absolute("foo/bar"))
+      assert PathGlob.match?("/**/foo", absolute("foo"))
+      refute PathGlob.match?("/**/foo", absolute("foo/bar"))
     end
   end
 

--- a/test/support/match_helper.ex
+++ b/test/support/match_helper.ex
@@ -35,7 +35,7 @@ defmodule PathGlob.MatchHelper do
     assert path in Path.wildcard(glob, opts),
            "expected #{wildcard_call(glob, opts)} to include '#{path}'"
 
-    assert PathGlob.match?(path, glob, opts),
+    assert PathGlob.match?(glob, path, opts),
            "expected '#{glob}' to match '#{path}'"
   end
 
@@ -43,7 +43,7 @@ defmodule PathGlob.MatchHelper do
     assert path not in Path.wildcard(glob, opts),
            "expected #{wildcard_call(glob, opts)} not to include '#{path}'"
 
-    refute PathGlob.match?(path, glob, opts),
+    refute PathGlob.match?(glob, path, opts),
            "expected '#{glob}' not to match '#{path}'"
   end
 
@@ -65,7 +65,7 @@ defmodule PathGlob.MatchHelper do
       _ -> raise "expected an error"
     end
 
-    assert_raise(ArgumentError, fn -> PathGlob.match?(path, glob) end)
+    assert_raise(ArgumentError, fn -> PathGlob.match?(glob, path) end)
   end
 
   def within_tmpdir(path, fun) do


### PR DESCRIPTION
Changes: 
- ability to pre-compile the pattern
- [breaking] changed order of arguments, so that pattern is the first one. 

Feel free to close it, because of the arguments order change. This might be a no-go for existing apps. I just thought, it's slightly more ergonomic.

Cheers and thanks for library, it seems to be the only one in Elixir  that is up-to-date and implementing the matching on pattern starting with `/` properly. 